### PR TITLE
Fix sort order of Bluesky repost

### DIFF
--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -52,6 +52,9 @@ jobs:
             RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
         - name: Installing PHP dependencies
           run: composer install
+        - name: Wait 1 minute for the database to be ready
+          run: sleep 60
+          if: github.event_name == 'pull_request'
         - name: Run migration
           run: php artisan migrate --force
           env:

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -54,7 +54,7 @@ jobs:
           run: composer install
         - name: Wait 1 minute for the database to be ready
           run: sleep 60
-          if: github.event_name == 'pull_request'
+          if: github.event_name == 'pull_request' && github.event.action == 'opened'
         - name: Run migration
           run: php artisan migrate --force
           env:

--- a/app/Services/DocumentSources/BlueskySource.php
+++ b/app/Services/DocumentSources/BlueskySource.php
@@ -28,7 +28,7 @@ class BlueskySource implements DocumentSource
             if ($authorDid !== $currentAccountDid) {
                 // repost
                 $text = "RP @{$postItem['author']['handle']}: {$postItem['record']['text']}";
-                $publishedAt = $postItem['reason']['by']['createdAt'];
+                $publishedAt = $item['reason']['by']['createdAt'];
             } elseif (isset($item['reply'])) {
                 $text = "@{$item['reply']['parent']['author']['handle']} {$postItem['record']['text']}";
             } else {

--- a/app/Services/DocumentSources/BlueskySource.php
+++ b/app/Services/DocumentSources/BlueskySource.php
@@ -28,7 +28,7 @@ class BlueskySource implements DocumentSource
             if ($authorDid !== $currentAccountDid) {
                 // repost
                 $text = "RP @{$postItem['author']['handle']}: {$postItem['record']['text']}";
-                $publishedAt = $item['reason']['by']['createdAt'];
+                $publishedAt = $item['reason']['indexedAt'];
             } elseif (isset($item['reply'])) {
                 $text = "@{$item['reply']['parent']['author']['handle']} {$postItem['record']['text']}";
             } else {

--- a/app/Services/DocumentSources/BlueskySource.php
+++ b/app/Services/DocumentSources/BlueskySource.php
@@ -23,10 +23,12 @@ class BlueskySource implements DocumentSource
             $postItem = $item['post'];
             $postId = str($postItem['uri'])->afterLast('/')->toString();
             $authorDid = $postItem['author']['did'];
+            $publishedAt = $postItem['record']['createdAt'];
 
             if ($authorDid !== $currentAccountDid) {
                 // repost
                 $text = "RP @{$postItem['author']['handle']}: {$postItem['record']['text']}";
+                $publishedAt = $postItem['reason']['by']['createdAt'];
             } elseif (isset($item['reply'])) {
                 $text = "@{$item['reply']['parent']['author']['handle']} {$postItem['record']['text']}";
             } else {
@@ -36,7 +38,7 @@ class BlueskySource implements DocumentSource
             $document = new DocumentData();
             $document->title = str($text)->limit(100)->toString();
             $document->url = "https://bsky.app/profile/{$authorDid}/post/{$postId}";
-            $document->publishedAt = $postItem['record']['createdAt'];
+            $document->publishedAt = $publishedAt;
             $document->sourceName = $this->getSourceName();
             return $document;
         }, $feed['data']['feed']);


### PR DESCRIPTION
Fix an issue wherein Bluesky reposts are sorted based on original post date, not repost date.
Here, the repost should appear in the second place, same as on [bsky social](https://bsky.app/profile/kuropen.org).
